### PR TITLE
Add MSVC compatibility

### DIFF
--- a/lib/windows_amd64/dabsdr.h
+++ b/lib/windows_amd64/dabsdr.h
@@ -5,6 +5,13 @@
 #include <stdlib.h>
 #include "dabsdr_export.h"
 
+#if defined(_MSC_VER)
+  #include <complex.h>
+  #undef I
+#else
+  #define _Fcomplex float _Complex
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -277,7 +284,7 @@ typedef struct
 } dabsdrXpadAppStartStop_t;
 
 // input functions
-typedef void (*dabsdrInputFunc_t)(float _Complex [], uint16_t);
+typedef void (*dabsdrInputFunc_t)(_Fcomplex *, uint16_t);
 
 // callback types
 typedef void (*dabsdrAudioCBFunc_t)(dabsdrAudioCBData_t * p, void * ctx);


### PR DESCRIPTION
Use `<complex.h>` for MSVC (and clang-cl) since it does not support the `float _Complex` construct.

And undefine `I` to avoid errors on template args `<I>` etc.