### PR TITLE
English texts in ensemble information added

### DIFF
--- a/gui/dabtables.cpp
+++ b/gui/dabtables.cpp
@@ -201,6 +201,45 @@ QString DabTables::getPtyName(const uint8_t pty)
     };
 }
 
+QString DabTables::getPtyNameEnglish(const uint8_t pty)
+{
+    switch (pty)
+    {
+        case 1: return QString("News");
+        case 2: return QString("Current Affairs");
+        case 3: return QString("Information");
+        case 4: return QString("Sport");
+        case 5: return QString("Education");
+        case 6: return QString("Drama");
+        case 7: return QString("Culture");
+        case 8: return QString("Science");
+        case 9: return QString("Varied");
+        case 10: return QString("Pop Music");
+        case 11: return QString("Rock Music");
+        case 12: return QString("Easy Listening Music");
+        case 13: return QString("Light Classical");
+        case 14: return QString("Serious Classical");
+        case 15: return QString("Other Music");
+        case 16: return QString("Weather/meteorology");
+        case 17: return QString("Finance/Business");
+        case 18: return QString("Children's programmes");
+        case 19: return QString("Social Affairs");
+        case 20: return QString("Religion");
+        case 21: return QString("Phone In");
+        case 22: return QString("Travel");
+        case 23: return QString("Leisure");
+        case 24: return QString("Jazz Music");
+        case 25: return QString("Country Music");
+        case 26: return QString("National Music");
+        case 27: return QString("Oldies Music");
+        case 28: return QString("Folk Music");
+        case 29: return QString("Documentary");
+        case 30: return QString("");
+        case 31: return QString("");
+        default: return QString("None");
+    };
+}
+
 QString DabTables::getLangName(int lang)
 {
     switch (lang)
@@ -310,6 +349,118 @@ QString DabTables::getLangName(int lang)
         case 0x7E: return QString(QObject::tr("Arabic"));
         case 0x7F: return QString(QObject::tr("Amharic"));
         default: return QString(QObject::tr("Unknown"));
+    }
+}
+
+QString DabTables::getLangNameEnglish(int lang)
+{
+    switch (lang)
+    {
+        case 0x00: return QString("Unknown/NA");
+        case 0x01: return QString("Albanian");
+        case 0x02: return QString("Breton");
+        case 0x03: return QString("Catalan");
+        case 0x04: return QString("Croatian");
+        case 0x05: return QString("Welsh");
+        case 0x06: return QString("Czech");
+        case 0x07: return QString("Danish");
+        case 0x08: return QString("German");
+        case 0x09: return QString("English");
+        case 0x0A: return QString("Spanish");
+        case 0x0B: return QString("Esperanto");
+        case 0x0C: return QString("Estonian");
+        case 0x0D: return QString("Basque");
+        case 0x0E: return QString("Faroese");
+        case 0x0F: return QString("French");
+        case 0x10: return QString("Frisian");
+        case 0x11: return QString("Irish");
+        case 0x12: return QString("Gaelic");
+        case 0x13: return QString("Galician");
+        case 0x14: return QString("Icelandic");
+        case 0x15: return QString("Italian");
+        case 0x16: return QString("Lappish");
+        case 0x17: return QString("Latin");
+        case 0x18: return QString("Latvian");
+        case 0x19: return QString("Luxembourgian");
+        case 0x1A: return QString("Lithuanian");
+        case 0x1B: return QString("Hungarian");
+        case 0x1C: return QString("Maltese");
+        case 0x1D: return QString("Dutch");
+        case 0x1E: return QString("Norwegian");
+        case 0x1F: return QString("Occitan");
+        case 0x20: return QString("Polish");
+        case 0x21: return QString("Portuguese");
+        case 0x22: return QString("Romanian");
+        case 0x23: return QString("Romansh");
+        case 0x24: return QString("Serbian");
+        case 0x25: return QString("Slovak");
+        case 0x26: return QString("Slovene");
+        case 0x27: return QString("Finnish");
+        case 0x28: return QString("Swedish");
+        case 0x29: return QString("Turkish");
+        case 0x2A: return QString("Flemish");
+        case 0x2B: return QString("Walloon");
+        case 0x40: return QString("Background sound/clean feed");
+        case 0x45: return QString("Zulu");
+        case 0x46: return QString("Vietnamese");
+        case 0x47: return QString("Uzbek");
+        case 0x48: return QString("Urdu");
+        case 0x49: return QString("Ukranian");
+        case 0x4A: return QString("Thai");
+        case 0x4B: return QString("Telugu");
+        case 0x4C: return QString("Tatar");
+        case 0x4D: return QString("Tamil");
+        case 0x4E: return QString("Tadzhik");
+        case 0x4F: return QString("Swahili");
+        case 0x50: return QString("Sranan Tongo");
+        case 0x51: return QString("Somali");
+        case 0x52: return QString("Sinhalese");
+        case 0x53: return QString("Shona");
+        case 0x54: return QString("Serbo-Croat");
+        case 0x55: return QString("Rusyn");
+        case 0x56: return QString("Russian");
+        case 0x57: return QString("Quechua");
+        case 0x58: return QString("Pushtu");
+        case 0x59: return QString("Punjabi");
+        case 0x5A: return QString("Persian");
+        case 0x5B: return QString("Papiamento");
+        case 0x5C: return QString("Oriya");
+        case 0x5D: return QString("Nepali");
+        case 0x5E: return QString("Ndebele");
+        case 0x5F: return QString("Marathi");
+        case 0x60: return QString("Moldavian");
+        case 0x61: return QString("Malaysian");
+        case 0x62: return QString("Malagasay");
+        case 0x63: return QString("Macedonian");
+        case 0x64: return QString("Laotian");
+        case 0x65: return QString("Korean");
+        case 0x66: return QString("Khmer");
+        case 0x67: return QString("Kazakh");
+        case 0x68: return QString("Kannada");
+        case 0x69: return QString("Japanese");
+        case 0x6A: return QString("Indonesian");
+        case 0x6B: return QString("Hindi");
+        case 0x6C: return QString("Hebrew");
+        case 0x6D: return QString("Hausa");
+        case 0x6E: return QString("Gurani");
+        case 0x6F: return QString("Gujurati");
+        case 0x70: return QString("Greek");
+        case 0x71: return QString("Georgian");
+        case 0x72: return QString("Fulani");
+        case 0x73: return QString("Dari");
+        case 0x74: return QString("Chuvash");
+        case 0x75: return QString("Chinese");
+        case 0x76: return QString("Burmese");
+        case 0x77: return QString("Bulgarian");
+        case 0x78: return QString("Bengali");
+        case 0x79: return QString("Belorussian");
+        case 0x7A: return QString("Bambora");
+        case 0x7B: return QString("Azerbaijani");
+        case 0x7C: return QString("Assamese");
+        case 0x7D: return QString("Armenian");
+        case 0x7E: return QString("Arabic");
+        case 0x7F: return QString("Amharic");
+        default: return QString("Unknown");
     }
 }
 
@@ -576,6 +727,272 @@ QString DabTables::getCountryName(uint32_t SId)
         case 0xF3F: return QString(QObject::tr("Mongolia"));
 
         default: return QString(QObject::tr("Unknown"));
+        }
+}
+
+QString DabTables::getCountryNameEnglish(uint32_t SId)
+{
+    int countryId = 0; // [ECC 8 bits | country code 4 bits]
+
+    // ETSI EN 300 401 V2.1.1 (2017-01) [6.3.1  Basic service and service component definition ]
+    if (SId > 0x00FFFFFF)
+    {   // data service
+        countryId = (SId >> 20) & 0x0FFF;
+    }
+    else
+    {   // program service
+        countryId = (SId >> 12) & 0x0FFF;
+    }
+    switch (countryId)
+    {
+        case 0xA01:
+        case 0xA02:
+        case 0xA03:
+        case 0xA04:
+        case 0xA05:
+        case 0xA06:
+        case 0xA07:
+        case 0xA08:
+        case 0xA09:
+        case 0xA0A:
+        case 0xA0B:
+        case 0xA0D:
+        case 0xA0E: return QString("USA/Puerto Rico");
+        case 0xA1B:
+        case 0xA1C:
+        case 0xA1D:
+        case 0xA1E: return QString("Canada");
+        case 0xA1F: return QString("Greenland");
+        case 0xA21: return QString("Anguilla");
+        case 0xA22: return QString("Antigua and Barbuda");
+        case 0xA23: return QString("Ecuador");
+        case 0xA24: return QString("Falkland Islands");
+        case 0xA25: return QString("Barbados");
+        case 0xA26: return QString("Belize");
+        case 0xA27: return QString("Cayman Islands");
+        case 0xA28: return QString("Costa Rica");
+        case 0xA29: return QString("Cuba");
+        case 0xA2A: return QString("Argentina");
+        case 0xA2B: return QString("Brazil");
+        case 0xA2C: return QString("Bermuda");
+        case 0xA2D: return QString("Netherlands Antilles");
+        case 0xA2E: return QString("Guadeloupe");
+        case 0xA2F: return QString("Bahamas");
+        case 0xA31: return QString("Bolivia");
+        case 0xA32: return QString("Colombia");
+        case 0xA33: return QString("Jamaica");
+        case 0xA34: return QString("Martinique");
+        case 0xA36: return QString("Paraguay");
+        case 0xA37: return QString("Nicaragua");
+        case 0xA39: return QString("Panama");
+        case 0xA3A: return QString("Dominica");
+        case 0xA3B: return QString("Dominican Republic");
+        case 0xA3C: return QString("Chile");
+        case 0xA3D: return QString("Grenada");
+        case 0xA3E: return QString("Turks and Caicos islands");
+        case 0xA3F: return QString("Guyana");
+        case 0xA41: return QString("Guatemala");
+        case 0xA42: return QString("Honduras");
+        case 0xA43: return QString("Aruba");
+        case 0xA45: return QString("Montserrat");
+        case 0xA46: return QString("Trinidad and Tobago");
+        case 0xA47: return QString("Peru");
+        case 0xA48: return QString("Surinam");
+        case 0xA49: return QString("Uruguay");
+        case 0xA4A: return QString("St. Kitts");
+        case 0xA4B: return QString("St. Lucia");
+        case 0xA4C: return QString("El Salvador");
+        case 0xA4D: return QString("Haiti");
+        case 0xA4E: return QString("Venezuela");
+        case 0xA5B: return QString("Mexico");
+        case 0xA5C: return QString("St. Vincent");
+        case 0xA5D:
+        case 0xA5E:
+        case 0xA5F: return QString("Mexico");
+        //case 0xA5F: return QString("Virgin islands (British)");
+        case 0xA63:
+        case 0xA6C:
+        case 0xA6D: return QString("Brazil");
+        case 0xA6F: return QString("St. Pierre and Miquelon");
+
+        case 0xD01: return QString("Cameroon");
+        case 0xD02: return QString("Central African Republic");
+        case 0xD03: return QString("Djibouti");
+        case 0xD04: return QString("Madagascar");
+        case 0xD05: return QString("Mali");
+        case 0xD06: return QString("Angola");
+        case 0xD07: return QString("Equatorial Guinea");
+        case 0xD08: return QString("Gabon");
+        case 0xD09: return QString("Republic of Guinea");
+        case 0xD0A: return QString("South Africa");
+        case 0xD0B: return QString("Burkina Faso");
+        case 0xD0C: return QString("Congo");
+        case 0xD0D: return QString("Togo");
+        case 0xD0E: return QString("Benin");
+        case 0xD0F: return QString("Malawi");
+        case 0xD11: return QString("Namibia");
+        case 0xD12: return QString("Liberia");
+        case 0xD13: return QString("Ghana");
+        case 0xD14: return QString("Mauritania");
+        case 0xD15: return QString("Sao Tome and Principe");
+        case 0xD16: return QString("Cape Verde");
+        case 0xD17: return QString("Senegal");
+        case 0xD18: return QString("Gambia");
+        case 0xD19: return QString("Burundi");
+        case 0xD1A: return QString("Ascension Island");
+        case 0xD1B: return QString("Botswana");
+        case 0xD1C: return QString("Comoros");
+        case 0xD1D: return QString("Tanzania");
+        case 0xD1E: return QString("Ethiopia");
+        case 0xD1F: return QString("Nigeria");
+        case 0xD21: return QString("Sierra Leone");
+        case 0xD22: return QString("Zimbabwe");
+        case 0xD23: return QString("Mozambique");
+        case 0xD24: return QString("Uganda");
+        case 0xD25: return QString("Swaziland");
+        case 0xD26: return QString("Kenya");
+        case 0xD27: return QString("Somalia");
+        case 0xD28: return QString("Niger");
+        case 0xD29: return QString("Chad");
+        case 0xD2A: return QString("Guinea-Bissau");
+        case 0xD2B: return QString("Zaire");
+        case 0xD2C: return QString("Cote d'Ivoire");
+        case 0xD2D: return QString("Zanzibar");
+        case 0xD2E: return QString("Zambia");
+        case 0xD33: return QString("Western Sahara");
+        case 0xD35: return QString("Rwanda");
+        case 0xD36: return QString("Lesotho");
+        case 0xD38: return QString("Seychelles");
+        case 0xD3A: return QString("Mauritius");
+        case 0xD3C: return QString("Sudan");
+
+        case 0xE01: return QString("Germany");
+        case 0xE02: return QString("Algeria");
+        case 0xE03: return QString("Andorra");
+        case 0xE04: return QString("Israel");
+        case 0xE05: return QString("Italy");
+        case 0xE06: return QString("Belgium");
+        case 0xE07: return QString("Russian Federation");
+        case 0xE08: return QString("Palestine");
+        case 0xE09: return QString("Albania");
+        case 0xE0A: return QString("Austria");
+        case 0xE0B: return QString("Hungary");
+        case 0xE0C: return QString("Malta");
+        case 0xE0D: return QString("Germany");
+        case 0xE0F: return QString("Egypt");
+        case 0xE11: return QString("Greece");
+        case 0xE12: return QString("Cyprus");
+        case 0xE13: return QString("San Marino");
+        case 0xE14: return QString("Switzerland");
+        case 0xE15: return QString("Jordan");
+        case 0xE16: return QString("Finland");
+        case 0xE17: return QString("Luxembourg");
+        case 0xE18: return QString("Bulgaria");
+        case 0xE19: return QString("Denmark");
+        //case 0xE19: return QString("Faroe");
+        case 0xE1A: return QString("Gibraltar");
+        case 0xE1B: return QString("Iraq");
+        case 0xE1C: return QString("United Kingdom");
+        case 0xE1D: return QString("Libya");
+        case 0xE1E: return QString("Romania");
+        case 0xE1F: return QString("France");
+        case 0xE21: return QString("Morocco");
+        case 0xE22: return QString("Czech Republic");
+        case 0xE23: return QString("Poland");
+        case 0xE24: return QString("Vatican");
+        case 0xE25: return QString("Slovakia");
+        case 0xE26: return QString("Syria");
+        case 0xE27: return QString("Tunisia");
+        case 0xE29: return QString("Liechtenstein");
+        case 0xE2A: return QString("Iceland");
+        case 0xE2B: return QString("Monaco");
+        case 0xE2C: return QString("Lithuania");
+        case 0xE2D: return QString("Serbia");
+        case 0xE2E: return QString("Spain");
+        //case 0xE2E: return QString("Canary Islands");
+        case 0xE2F: return QString("Norway");
+        case 0xE31: return QString("Montenegro");
+        case 0xE32: return QString("Ireland");
+        case 0xE33: return QString("Turkey");
+        case 0xE35: return QString("Tajikistan");
+        case 0xE38: return QString("Netherlands");
+        case 0xE39: return QString("Latvia");
+        case 0xE3A: return QString("Lebanon");
+        case 0xE3B: return QString("Azerbaijan");
+        case 0xE3C: return QString("Croatia");
+        case 0xE3D: return QString("Kazakhstan");
+        case 0xE3E: return QString("Sweden");
+        case 0xE3F: return QString("Belarus");
+        case 0xE41: return QString("Moldova");
+        case 0xE42: return QString("Estonia");
+        case 0xE43: return QString("Macedonia");
+        case 0xE46: return QString("Ukraine");
+        case 0xE47: return QString("Kosovo");
+        //case 0xE48: return QString("Azores");
+        //case 0xE48: return QString("Madeira");
+        case 0xE48: return QString("Portugal");
+        case 0xE49: return QString("Slovenia");
+        case 0xE4A: return QString("Armenia");
+        case 0xE4B: return QString("Uzbekistan");
+        case 0xE4C: return QString("Georgia");
+        case 0xE4E: return QString("Turkmenistan");
+        case 0xE4F: return QString("Bosnia Herzegovina");
+        case 0xE53: return QString("Kyrgyzstan");
+
+        case 0xF01: return QString("Australia: Capital Cities (commercial and community broadcasters)");
+        case 0xF02: return QString("Australia: Regional New South Wales and ACT");
+        case 0xF03: return QString("Australia: Capital Cities (national broadcasters)");
+        case 0xF04: return QString("Australia: Regional Queensland");
+        case 0xF05: return QString("Australia: Regional South Australia and Northern Territory");
+        case 0xF06: return QString("Australia: Regional Western Australia");
+        case 0xF07: return QString("Australia: Regional Victoria and Tasmania");
+        case 0xF08: return QString("Australia: Regional (future)");
+        case 0xF09: return QString("Saudi Arabia");
+        case 0xF0A: return QString("Afghanistan");
+        case 0xF0B: return QString("Myanmar (Burma)");
+        case 0xF0C: return QString("China");
+        case 0xF0D: return QString("Korea (North)");
+        case 0xF0E: return QString("Bahrain");
+        case 0xF0F: return QString("Malaysia");
+        case 0xF11: return QString("Kiribati");
+        case 0xF12: return QString("Bhutan");
+        case 0xF13: return QString("Bangladesh");
+        case 0xF14: return QString("Pakistan");
+        case 0xF15: return QString("Fiji");
+        case 0xF16: return QString("Oman");
+        case 0xF17: return QString("Nauru");
+        case 0xF18: return QString("Iran");
+        case 0xF19: return QString("New Zealand");
+        case 0xF1A: return QString("Solomon Islands");
+        case 0xF1B: return QString("Brunei Darussalam");
+        case 0xF1C: return QString("Sri Lanka");
+        case 0xF1D: return QString("Taiwan");
+        case 0xF1E: return QString("Korea (South)");
+        case 0xF1F: return QString("Hong Kong");
+        case 0xF21: return QString("Kuwait");
+        case 0xF22: return QString("Qatar");
+        case 0xF23: return QString("Cambodia");
+        case 0xF24: return QString("Western Samoa");
+        case 0xF25: return QString("India");
+        case 0xF26: return QString("Macau");
+        case 0xF27: return QString("Vietnam");
+        case 0xF28: return QString("Philippines");
+        case 0xF29: return QString("Japan");
+        case 0xF2A: return QString("Singapore");
+        case 0xF2B: return QString("Maldives");
+        case 0xF2C: return QString("Indonesia");
+        case 0xF2D: return QString("United Arab Emirates");
+        case 0xF2E: return QString("Nepal");
+        case 0xF2F: return QString("Vanuatu");
+        case 0xF31: return QString("Laos");
+        case 0xF32: return QString("Thailand");
+        case 0xF33: return QString("Tonga");
+        case 0xF39: return QString("Papua New Guinea");
+        case 0xF3B: return QString("Yemen");
+        case 0xF3E: return QString("Micronesia");
+        case 0xF3F: return QString("Mongolia");
+
+        default: return QString("Unknown");
         }
 }
 

--- a/gui/dabtables.h
+++ b/gui/dabtables.h
@@ -139,8 +139,11 @@ public:
     static const QList<uint16_t> ASwValues;
     static QString convertToQString(const char *c, uint8_t charset, uint8_t len = 16);
     static QString getPtyName(const uint8_t pty);
+    static QString getPtyNameEnglish(const uint8_t pty);
     static QString getLangName(int lang);
+    static QString getLangNameEnglish(int lang);
     static QString getCountryName(uint32_t SId);
+    static QString getCountryNameEnglish(uint32_t SId);
     static QString getAnnouncementName(DabAnnouncement announcement);
     static QString getAnnouncementNameEnglish(DabAnnouncement announcement);
 };

--- a/gui/radiocontrol.cpp
+++ b/gui/radiocontrol.cpp
@@ -692,11 +692,12 @@ QString RadioControl::ensembleConfigurationString() const
 
     strOut << "<dl>";
     strOut << "<dt>Ensemble:</dt>";
-    strOut << QString("<dd>0x%1 <b>%2</b> [ <i>%3</i> ]  ECC = 0x%4, UTC %5 min, INT = %6, alarm announcements = %7</dd>")
+    strOut << QString("<dl><dt>0x%1 <b>%2</b> [ <i>%3</i> ]  </dt> <dd>ECC: 0x%4, Country: %5, UTC: %6 min, INT: %7, alarm announcements: %8</dd></dl>")
               .arg(QString("%1").arg(m_ensemble.eid(), 4, 16, QChar('0')).toUpper())
               .arg(m_ensemble.label)
               .arg(m_ensemble.labelShort)
               .arg(QString("%1").arg(m_ensemble.ecc(), 2, 16, QChar('0')).toUpper())
+              .arg(DabTables::getCountryNameEnglish(m_ensemble.ueid))
               .arg(m_ensemble.LTO*30)
               .arg(m_ensemble.intTable)
               .arg(m_ensemble.alarm);
@@ -715,22 +716,23 @@ QString RadioControl::ensembleConfigurationString() const
         strOut << "<dt>";
         if (s.SId.isProgServiceId())
         {   // programme service
-            strOut << QString("0x%1 <b>%2</b> [ <i>%3</i> ] ECC = 0x%4,")
+            strOut << QString("0x%1 <b>%2</b> [ <i>%3</i> ]</dt> <dd>ECC: 0x%4, Country: %5,")
                               .arg(QString("%1").arg(s.SId.progSId(), 4, 16, QChar('0')).toUpper())
                               .arg(s.label)
                               .arg(s.labelShort)
-                              .arg(QString("%1").arg(s.SId.ecc(), 2, 16, QChar('0')).toUpper());
+                              .arg(QString("%1").arg(s.SId.ecc(), 2, 16, QChar('0')).toUpper())
+                              .arg(DabTables::getCountryNameEnglish(s.SId.value()));
 
             // ETSI EN 300 401 V2.1.1 [8.1.5]
             // At any one time, the PTy shall be either Static or Dynamic;
             // there shall be only one PTy per service.
             if (s.pty.d != 0)
             {
-                strOut << QString(" PTY: %1 (dynamic), ").arg(s.pty.d);
+                strOut << QString(" PTy: %1 (dynamic), ").arg(DabTables::getPtyNameEnglish(s.pty.d));
             }
             else
             {
-                strOut << QString(" PTY: %1 (static), ").arg(s.pty.s);
+                strOut << QString(" PTy: %1 (static), ").arg(DabTables::getPtyNameEnglish(s.pty.s));
             }
             if (0 == s.ASu)
             {
@@ -766,18 +768,18 @@ QString RadioControl::ensembleConfigurationString() const
         {
             strOut << QString(", CAId %1").arg(s.CAId);
         }
-        strOut << "</dt>";
+        strOut << "</dd>";
 
         for (auto const & sc : s.serviceComponents)
         {
             strOut << "<dd>";
             if (sc.isDataPacketService())
             {
-                strOut << "DataComponent (MSC Packet Data)";
+                strOut << "<dd>DataComponent (MSC Packet Data)";
                 strOut << ((sc.ps) ? " (primary)," : " (secondary),");
                 strOut << QString(" SCIdS: %1,").arg(sc.SCIdS);
                 strOut << QString(" SCId: %1,").arg(sc.packetData.SCId);
-                strOut << QString(" Language: %1,").arg(sc.lang);
+                strOut << QString(" Language: %1,").arg(DabTables::getLangNameEnglish(sc.lang));
             }
             else
             {
@@ -833,10 +835,10 @@ QString RadioControl::ensembleConfigurationString() const
             {  /* do nothing */ }
             strOut << "<br>";
 
-            strOut << "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
+//            strOut << "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
             strOut << QString("SubChId: %1, Language: %2, StartCU: %3, NumCU: %4,")
                       .arg(sc.SubChId)
-                      .arg(sc.lang)
+                      .arg(DabTables::getLangNameEnglish(sc.lang))
                       .arg(sc.SubChAddr)
                       .arg(sc.SubChSize);
             if (sc.protection.isEEP())
@@ -870,8 +872,8 @@ QString RadioControl::ensembleConfigurationString() const
             for (const auto & ua : sc.userApps)
             {
                 strOut << "<br>";
-                strOut << "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
-                strOut << "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
+//                strOut << "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
+//                strOut << "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
                 strOut << QString("UserApp %1/%2: Label: '%3' [ '%4' ], ")
                           .arg(uaCntr++).arg(sc.userApps.size())
                           .arg(ua.label)


### PR DESCRIPTION
As you have achieved to show `Traffic News` although this is translated to local language

![grafik](https://github.com/KejPi/AbracaDABra/assets/24510556/39386f7e-f68d-48e7-b8fd-e48a92686c19)

(see `getAnnouncementNameEnglish`) I have added some more QStrings

```
static QString getPtyNameEnglish(const uint8_t pty);
static QString getLangNameEnglish(int lang);
static QString getCountryNameEnglish(uint32_t SId);
```

![grafik](https://github.com/KejPi/AbracaDABra/assets/24510556/448ebf54-5c24-4e56-a4d8-ef37072b572d)

# change log

- added the country information in English (was missing before)
- PTy typo fixed
- changed `=` to `:`
- language in English

# To Do

- Layout broken for data services (too long line and not indented)
- Label and short label are already in the headline
- could you check if the HTML is valid and well-formed (`<dl>`, `<dt>` and `<dd>`)?