### PR TITLE
[SPI] Fix for MOT object contentName parameter encoded in utf8

### DIFF
--- a/gui/dabtables.cpp
+++ b/gui/dabtables.cpp
@@ -126,7 +126,7 @@ QString DabTables::convertToQString(const char *c, uint8_t charset, uint8_t len)
     switch (static_cast<DabCharset>(charset))
     {
     case DabCharset::UTF8:
-        out = out.fromUtf8(c);
+        out = out.fromUtf8(c, len);
         break;
     case DabCharset::UCS2:
     {


### PR DESCRIPTION
The length was omitted when parsing the utf8 string, causing the names to append garbage data before. This PR simply pass in the calculated length to `fromUtf8()`

The SPI logos would not display at all in the GUI before, but after this fix they appear.