### PR TITLE
fix: add missing include QRegularExpression in spiapp

### DIFF
--- a/gui/data/spiapp.cpp
+++ b/gui/data/spiapp.cpp
@@ -33,6 +33,7 @@
 #include <QNetworkDiskCache>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QRegularExpression>
 #include <QSaveFile>
 #include <QStandardPaths>
 


### PR DESCRIPTION
On NixOS the current version (3.1.0) results in a compile error, since QRegularExpression is not included in `spiapp.cpp` 

See here: https://github.com/NixOS/nixpkgs/pull/400171